### PR TITLE
Fixed error in sample rename command

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ pokit status --device RedPokitPro
 Tip: You can rename Pokit devices via the official Pokit app, or the `set-name` command, like:
 
 ```sh
-pokit set-name --device PokitMeter --new-name MyPokitMeter
+pokit set-name --device Pokit --new-name PokitMeter
 ```
 
 Here's a more complex usage example:


### PR DESCRIPTION
On execution of the renaming sample command, I've got this error.

```
$ pokit set-name --device Pokit --new-name MyPokitMeter
qt.bluetooth.bluez: Missing CAP_NET_ADMIN permission. Cannot determine whether a found address is of random or public type.
QtPokit: New name cannot exceed 11 characters.
```
This PR reduces the length of the new device name. The initial device name after unboxing Pokit Meter was "Pokit".